### PR TITLE
Fix fatal error blocks_intelligent_learning_model_service_course_categories_test

### DIFF
--- a/tests/classes/privacy/provider_test.php
+++ b/tests/classes/privacy/provider_test.php
@@ -27,10 +27,8 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require($CFG->dirroot.'/local/mr/bootstrap.php');
 require_once($CFG->dirroot.'/blocks/intelligent_learning/classes/privacy/provider.php');
-require_once($CFG->dirroot.'/privacy/tests/provider_test.php');
 
 use \core_privacy\local\request\transform;
-
 
 /**
  * Unit tests for block_intelligent_learning/classes/privacy/provider

--- a/tests/model/service/course_categories_test.php
+++ b/tests/model/service/course_categories_test.php
@@ -7,7 +7,7 @@ require_once($CFG->dirroot.'/blocks/intelligent_learning/model/service/course_ca
 require_once($CFG->dirroot.'/blocks/intelligent_learning/model/response.php');
 
 class blocks_intelligent_learning_model_service_course_categories_test extends advanced_testcase {
-    protected function setUp() {
+    protected function setUp(): void {
         $this->resetAfterTest();
     }
 

--- a/tests/model/service/course_test.php
+++ b/tests/model/service/course_test.php
@@ -7,7 +7,7 @@ require_once($CFG->dirroot.'/blocks/intelligent_learning/model/service/course.ph
 require_once($CFG->dirroot.'/blocks/intelligent_learning/model/response.php');
 
 class blocks_intelligent_learning_model_service_course_test extends advanced_testcase {
-    protected function setUp() {
+    protected function setUp(): void {
         $this->resetAfterTest();
     }
 


### PR DESCRIPTION
Uniut test are throwing a fatal error:

PHP Fatal error:  Declaration of blocks_intelligent_learning_model_service_course_categories_test::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /var/www/site/blocks/intelligent_learning/tests/model/service/course_categories_test.php on line 10


